### PR TITLE
Fix/header text

### DIFF
--- a/sbr_ui/templates/layout.html
+++ b/sbr_ui/templates/layout.html
@@ -51,8 +51,12 @@
                 <div class="wrapper">
                     <div class="group">
                         <div class="col-12">
+                            {%- if request.path == "/Home" %}
                             <h1 class="jupiter main_heading">Statistical Business Register</h1>
                             <h2 class="neptune sub_heading">A comprehensive list of UK businesses used by government for statistical purposes</h2>
+                            {% else %}
+                            <p class="saturn main_heading_sub_page">Statistical Business Register</p>
+                            {% endif %}
                         </div>
                     </div>
                 </div>

--- a/sbr_ui/templates/layout.html
+++ b/sbr_ui/templates/layout.html
@@ -51,7 +51,7 @@
                 <div class="wrapper">
                     <div class="group">
                         <div class="col-12">
-                            {%- if request.path == "/Home" %}
+                            {%- if request.path == "/Home" or request.path == "/" %}
                             <h1 class="jupiter main_heading">Statistical Business Register</h1>
                             <h2 class="neptune sub_heading">A comprehensive list of UK businesses used by government for statistical purposes</h2>
                             {% else %}


### PR DESCRIPTION
- Add path dependant title text, when on `/Home` or `/` (login page), display the text in a bigger font and include the description, on other pages omit the description and use a smaller font